### PR TITLE
disable warning in Unity2018.3

### DIFF
--- a/Editor/LWRPShaderIncludes.cs
+++ b/Editor/LWRPShaderIncludes.cs
@@ -7,7 +7,9 @@ namespace LWRPShaders
 {
     public static class LWRPShaderIncludes
     {
+#pragma warning disable 618
         [ShaderIncludePath]
+#pragma warning restore 618
         public static string[] GetPaths()
         {
             var root = Directory.GetParent(Application.dataPath);


### PR DESCRIPTION
`"[ShaderIncludePath] attribute is being obsoleted. Your shader library should be under the Assets folder or in a package. To include shader headers directly from a package, use #include \"Packages/<package name>/<path to your header file>\"`